### PR TITLE
Added method to reshape array with two possible ratio arrays

### DIFF
--- a/MODIS_API/k_means_method.py
+++ b/MODIS_API/k_means_method.py
@@ -1,7 +1,7 @@
 """LEAVE ME ALONE PYLINTER"""
 from sklearn.cluster import KMeans
 
-def create_labels_colors(input_image, clusters=5):
+def create_labels_colors(input_image, clusters=5, ratio_array1=None, ratio_array2=None):
     """
     Create labels and colors array from k-means classifier
     @param: input_image - Receives a 2D array representation of an image in the form of 
@@ -10,27 +10,39 @@ def create_labels_colors(input_image, clusters=5):
     @return: colors_array, classification array of length clusters OR empty array on failure
     @return: labels_array, array of category of input array OR empty array on failure
     """
+    
     if (not isinstance(clusters, int) or not isinstance(input_image, list)):
         return ([], [])
 
+    reshaped_image = reshape_data(input_image, ratio_array1, ratio_array2)
+    
+
     kmeans = KMeans(clusters)
-    kmeans.fit(input_image)
+    kmeans.fit(reshaped_image)
 
     colors_array = kmeans.cluster_centers_.astype(int)
 
     labels_array = kmeans.labels_
 
-    return (colors_array, labels_array)
+    return (reshaped_image, colors_array, labels_array)
+
+
+# Assuming the (0, 0) and row major.
+def reshape_data(input_data, ratio_array1=None, ratio_array2=None):
+    reshaped_image = []
+    x_length = len(input_data[0][0])
+    y_length = len(input_data[0])
+
+
+    for row in range(y_length):
+        for col in range(x_length):
+            rgb_and_ratios = [input_data[0][row][col], input_data[1][row][col], input_data[2][row][col]]
+            if ratio_array1 is None:
+                rgb_and_ratios.append(ratio_array1[row][col])
+
+            if ratio_array2 is None:
+                rgb_and_ratios.append(ratio_array2[row][col])
+
+            reshaped_image.append(rgb_and_ratios)
     
-# Use Example
-# TEST_IMAGE = [
-#     [3, 4, 2, 2], [3, 2, 44, 0.5], [4, 25, 62, 0.5], [23, 54, 66, 0.3], [52, 122, 240, 0.1],
-#     [3, 4, 2, 2], [3, 2, 44, 0.5], [4, 25, 62, 0.5], [23, 54, 66, 0.3], [52, 122, 240, 0.1],
-#     [3, 4, 2, 2], [3, 2, 44, 0.5], [4, 25, 62, 0.5], [23, 54, 66, 0.3], [52, 122, 240, 0.1],
-#     [3, 4, 2, 2], [3, 2, 44, 0.5], [4, 25, 62, 0.5], [23, 54, 66, 0.3], [52, 122, 240, 0.1],
-#     [3, 4, 2, 2], [3, 2, 44, 0.5], [4, 25, 62, 0.5], [23, 54, 66, 0.3], [52, 122, 240, 0.1],
-#     [3, 4, 2, 2], [3, 2, 44, 0.5], [4, 25, 62, 0.5], [23, 54, 66, 0.3], [52, 122, 240, 0.1]]
-   
-# COLORS, LABELS = create_labels_colors(TEST_IMAGE, 5)
-# print(COLORS)
-# print(LABELS)
+    return reshaped_image


### PR DESCRIPTION
Let me know if this is incorrect.

**Assumptions:**
- Image is in the form [3][Y][X] so a list of 2D arrays in row major.
- Assuming [0][y][x] = red, [1][y][x] = green, [2][y][x] = blue
- Ratios are 2D arrays also in row major
- Assuming (0,0) is top left corner for ratios and images

**PS:** If there is a method that does this (like from OG code throwaway pr bish)